### PR TITLE
Fix rare app crash when showing Invalid message dialog

### DIFF
--- a/callback/callbacks.py
+++ b/callback/callbacks.py
@@ -255,13 +255,11 @@ def new_message_callback(packet: Packet, peer: Peer, window):
 
 
 def invalid_message_callback(reason, message, peer):
-    client_base.invalid_message_callback = None
     alert_box = QMessageBox()
     alert_box.setWindowTitle("Invalid message received")
     alert_box.setText("Reason:\n{}\nFrom:{}:{}\n\nMessage:\n{}".format(reason, peer.host, peer.port, message))
     alert_box.setStandardButtons(QMessageBox.Ok)
     alert_box.exec_()
-    client_base.invalid_message_callback = invalid_message_callback
 
 
 def delete_dialog_callback(peer_id: str, host: str, port: int):

--- a/main.py
+++ b/main.py
@@ -35,14 +35,20 @@ init_databases()
 # noinspection PyUnresolvedReferences
 class MainWindow(QMainWindow):
     new_message_signal = pyqtSignal(Packet, Peer)
+    invalid_message_signal = pyqtSignal(str, str, Peer)
 
     @pyqtSlot(Packet, Peer)
     def new_message_received_slot(self, packet: Packet, peer: Peer):
         new_message_callback(packet, peer, main_window)
 
+    @pyqtSlot(str, str, Peer)
+    def invalid_message_received_slot(self, reason: str, message: str, peer: Peer):
+        invalid_message_callback(reason, message, peer)
+
     def __init__(self):
         super().__init__()
         self.new_message_signal.connect(self.new_message_received_slot)
+        self.invalid_message_signal.connect(self.invalid_message_received_slot)
         self.init_ui()
 
     def init_ui(self):
@@ -120,7 +126,7 @@ class MainWindow(QMainWindow):
 
         client_base.init_socket()
         client_base.new_message_callback = lambda message, peer: self.new_message_signal.emit(message, peer)
-        client_base.invalid_message_callback = invalid_message_callback
+        client_base.invalid_message_callback = lambda reason, message, peer: self.invalid_message_signal.emit(reason, message, peer)
 
     @staticmethod
     def open_settings():


### PR DESCRIPTION
## Summary

This PR fixes the rare app crash that occurs when pressing the OK button of the "Invalid message" dialog.

## Problem

The crash was caused by incorrect work with threads and window objects. The `invalid_message_callback` was being called from background message listener threads (`p2p_new_message_listener` and `server_new_message_listener`), but it was creating and showing a `QMessageBox` directly. In Qt, GUI operations must be performed from the main thread, so this caused crashes with errors like:

- `QBackingStore::endPaint() called with active painter on backingstore paint device`
- SIGSEGV (code 139)
- SIGABRT (code 134)
- `munmap_chunk(): invalid pointer`

## Solution

Used Qt's signal/slot mechanism to ensure the Invalid message dialog is shown on the main thread instead of the background message listener thread. This follows the same pattern already used for `new_message_callback`:

1. Added `invalid_message_signal = pyqtSignal(str, str, Peer)` to `MainWindow`
2. Added `invalid_message_received_slot` that calls the actual callback function
3. Updated the callback assignment to emit the signal: `lambda reason, message, peer: self.invalid_message_signal.emit(reason, message, peer)`

Also removed the callback manipulation code in `invalid_message_callback` that was setting the callback to `None` and restoring it, as this was a workaround that doesn't work properly with the signal-based approach.

Fixes #6

@arterialist can click here to [continue refining the PR](https://app.all-hands.dev/conversations/4b69cccdd4db4dafadba373495e7f63e)